### PR TITLE
Fix repository URL

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "main": "./lib/index.js",
   "repository": {
     "type": "git",
-    "url": "git://github.com/username/repository.git"
+    "url": "https://github.com/meraki/meraki-node-sdk.git"
   },
   "scripts": {
     "lint": "eslint lib"


### PR DESCRIPTION
This is a small fix to make the published SDK package correctly link to the repository.

Without this, users of package repositories such as `npm` may have difficulty finding the correct source repository to contribute issues and bug requests.

Example can be found here, where `npm` links incorrectly to a non-existent location:
https://www.npmjs.com/package/meraki